### PR TITLE
Feature/maintain injectionnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ export class PromptState extends PromptStateMixin(PromptStateRequirements) {
     @inject(injectionNames.current.stateSetupSet) setupSet: MergedSetupSet,
     @inject(injectionNames.current.entityDictionary) entities: EntityDictionary,
     @inject(injectionNames.current.sessionFactory) sessionFactory: CurrentSessionFactory,
-    @inject("core:unifier:user-entity-mappings") mappings: PlatformGenerator.EntityMapping
+    @inject(injectionNames.userEntityMappings) mappings: PlatformGenerator.EntityMapping
   ) {
     super(setupSet, entities, sessionFactory, mappings);
   }
@@ -171,7 +171,7 @@ export class PromptState extends PromptStateMixin(PromptStateRequirements) {
     @inject(injectionNames.current.stateSetupSet) setupSet: MergedSetupSet,
     @inject(injectionNames.current.entityDictionary) entities: EntityDictionary,
     @inject(injectionNames.current.sessionFactory) sessionFactory: CurrentSessionFactory,
-    @inject("core:unifier:user-entity-mappings") mappings: PlatformGenerator.EntityMapping
+    @inject(injectionNames.userEntityMappings) mappings: PlatformGenerator.EntityMapping
   ) {
     super(setupSet, entities, sessionFactory, mappings);
   }

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Sometimes, you want to prompt for an entity based on some previous conditions. I
 ```typescript
 import { ApplicationState } from "./application";
 import { injectionNames, State, Transitionable } from "assistant-source";
-import { needs, PromptFactory, Prompt, injectionNames as validationsInjectionNames } from "assistant-validations";
+import { needs, PromptFactory, Prompt, validationsInjectionNames } from "assistant-validations";
 import { injectable, inject } from "inversify";
 import { MergedSetupSet } from "../../config/handler";
 

--- a/spec/prompt.spec.ts
+++ b/spec/prompt.spec.ts
@@ -1,5 +1,5 @@
 import { GenericIntent, injectionNames, State, Transitionable } from "assistant-source";
-import { validationsInjectionNames } from "../dts/components/validations/injection-names";
+import { validationsInjectionNames } from "../src/components/validations/injection-names";
 import { Prompt as PromptImpl } from "../src/components/validations/prompt";
 import { Prompt, PromptFactory } from "../src/components/validations/public-interfaces";
 import { ThisContext } from "./this-context";

--- a/spec/prompt.spec.ts
+++ b/spec/prompt.spec.ts
@@ -1,4 +1,5 @@
 import { GenericIntent, injectionNames, State, Transitionable } from "assistant-source";
+import { validationsInjectionNames } from "../dts/components/validations/injection-names";
 import { Prompt as PromptImpl } from "../src/components/validations/prompt";
 import { Prompt, PromptFactory } from "../src/components/validations/public-interfaces";
 import { ThisContext } from "./this-context";
@@ -18,7 +19,7 @@ describe("Prompt", function() {
     this.preparePrompt = async (promptStateName?: string, additionalArguments = []) => {
       await this.googleSpecHelper.pretendIntentCalled("test");
       this.machine = this.container.inversifyInstance.get(injectionNames.current.stateMachine);
-      this.prompt = this.container.inversifyInstance.get<PromptFactory>("validations:current-prompt-factory")(
+      this.prompt = this.container.inversifyInstance.get<PromptFactory>(validationsInjectionNames.current.promptFactory)(
         intent,
         state,
         this.machine,

--- a/spec/support/mocks/states/prompt.ts
+++ b/spec/support/mocks/states/prompt.ts
@@ -34,7 +34,7 @@ export class PromptState<MergedAnswerTypes extends BasicAnswerTypes, MergedHandl
     @inject(injectionNames.current.stateSetupSet) setupSet: State.SetupSet<MergedAnswerTypes, MergedHandler>,
     @inject(injectionNames.current.entityDictionary) entities: EntityDictionary,
     @inject(injectionNames.current.sessionFactory) sessionFactory: CurrentSessionFactory,
-    @inject("core:unifier:user-entity-mappings") mappings: PlatformGenerator.EntityMapping
+    @inject(injectionNames.userEntityMappings) mappings: PlatformGenerator.EntityMapping
   ) {
     super(setupSet, entities, sessionFactory, mappings);
   }

--- a/src/assistant-validations.ts
+++ b/src/assistant-validations.ts
@@ -2,3 +2,4 @@ export * from "./components/validations/public-interfaces";
 export { descriptor } from "./components/validations/descriptor";
 export { PromptStateMixin } from "./components/validations/prompt-state-mixin";
 export { needs } from "./components/validations/annotations";
+export { validationsInjectionNames } from "./components/validations/injection-names";

--- a/src/components/validations/descriptor.ts
+++ b/src/components/validations/descriptor.ts
@@ -2,6 +2,7 @@ import { injectionNames, PlatformGenerator, Transitionable } from "assistant-sou
 import { Component, ComponentDescriptor, Hooks } from "inversify-components";
 
 import { BeforeIntentHook } from "./hook";
+import { validationsInjectionNames } from "./injection-names";
 import { COMPONENT_NAME, Configuration } from "./private-interfaces";
 import { Prompt } from "./prompt";
 import { PromptFactory } from "./public-interfaces";
@@ -29,7 +30,7 @@ export const descriptor: ComponentDescriptor<Configuration.Defaults> = {
           // Grab default promptState by Configuration
           const currentpromptStateName =
             typeof promptStateName === "undefined"
-              ? context.container.get<Component<Configuration.Runtime>>("meta:component//validations").configuration.defaultPromptState
+              ? context.container.get<Component<Configuration.Runtime>>(validationsInjectionNames.component).configuration.defaultPromptState
               : promptStateName;
 
           return new Prompt(

--- a/src/components/validations/descriptor.ts
+++ b/src/components/validations/descriptor.ts
@@ -1,5 +1,5 @@
 import { injectionNames, PlatformGenerator, Transitionable } from "assistant-source";
-import { Component, ComponentDescriptor, Hooks } from "inversify-components";
+import { Component, ComponentDescriptor, getMetaInjectionName, Hooks } from "inversify-components";
 
 import { BeforeIntentHook } from "./hook";
 import { validationsInjectionNames } from "./injection-names";
@@ -30,7 +30,7 @@ export const descriptor: ComponentDescriptor<Configuration.Defaults> = {
           // Grab default promptState by Configuration
           const currentpromptStateName =
             typeof promptStateName === "undefined"
-              ? context.container.get<Component<Configuration.Runtime>>(validationsInjectionNames.component).configuration.defaultPromptState
+              ? context.container.get<Component<Configuration.Runtime>>(getMetaInjectionName(COMPONENT_NAME)).configuration.defaultPromptState
               : promptStateName;
 
           return new Prompt(

--- a/src/components/validations/hook.ts
+++ b/src/components/validations/hook.ts
@@ -1,7 +1,7 @@
 import { ComponentSpecificLoggerFactory, EntityDictionary, Hooks, injectionNames, Logger, State } from "assistant-source";
 import { inject, injectable } from "inversify";
 
-import { validationsInjectionNames } from "../../../dts/components/validations/injection-names";
+import { validationsInjectionNames } from "../../../src/components/validations/injection-names";
 import { needsMetadataKey } from "./annotations";
 import { COMPONENT_NAME } from "./private-interfaces";
 import { PromptFactory } from "./public-interfaces";

--- a/src/components/validations/hook.ts
+++ b/src/components/validations/hook.ts
@@ -1,9 +1,10 @@
 import { ComponentSpecificLoggerFactory, EntityDictionary, Hooks, injectionNames, Logger, State } from "assistant-source";
 import { inject, injectable } from "inversify";
 
+import { validationsInjectionNames } from "../../../dts/components/validations/injection-names";
 import { needsMetadataKey } from "./annotations";
 import { COMPONENT_NAME } from "./private-interfaces";
-import { injectionNames as ownInjectionNames, PromptFactory } from "./public-interfaces";
+import { PromptFactory } from "./public-interfaces";
 
 @injectable()
 export class BeforeIntentHook {
@@ -15,7 +16,7 @@ export class BeforeIntentHook {
 
   constructor(
     @inject(injectionNames.current.entityDictionary) private entities: EntityDictionary,
-    @inject(ownInjectionNames.current.promptFactory) private promptFactory: PromptFactory,
+    @inject(validationsInjectionNames.current.promptFactory) private promptFactory: PromptFactory,
     @inject(injectionNames.componentSpecificLoggerFactory) loggerFactory: ComponentSpecificLoggerFactory
   ) {
     this.logger = loggerFactory(COMPONENT_NAME);

--- a/src/components/validations/injection-names.ts
+++ b/src/components/validations/injection-names.ts
@@ -1,0 +1,16 @@
+/** Names of injectionable services, leads to fewer typing errors for most important injections */
+export const validationsInjectionNames = {
+  /**
+   * Inject an instance of @type {Component<Configuration.Runtime>}
+   */
+  component: "meta:component//validations",
+  /**
+   * Namespace for services which are only available in the request scope.
+   */
+  current: {
+    /**
+     * Inject an instance of @type {PromptFactory}}
+     */
+    promptFactory: "validations:current-prompt-factory",
+  },
+};

--- a/src/components/validations/injection-names.ts
+++ b/src/components/validations/injection-names.ts
@@ -1,10 +1,6 @@
 /** Names of injectionable services, leads to fewer typing errors for most important injections */
 export const validationsInjectionNames = {
   /**
-   * Inject an instance of @type {Component<Configuration.Runtime>}
-   */
-  component: "meta:component//validations",
-  /**
    * Namespace for services which are only available in the request scope.
    */
   current: {

--- a/src/components/validations/public-interfaces.ts
+++ b/src/components/validations/public-interfaces.ts
@@ -1,13 +1,6 @@
 import { CurrentSessionFactory, EntityDictionary, PlatformGenerator, Transitionable } from "assistant-source";
 import { Configuration } from "./private-interfaces";
 
-/** Injection names of validations component */
-export const injectionNames = {
-  current: {
-    promptFactory: "validations:current-prompt-factory",
-  },
-};
-
 export interface HookContext {
   intent: string;
   state: string;

--- a/src/components/validations/public-interfaces.ts
+++ b/src/components/validations/public-interfaces.ts
@@ -34,13 +34,13 @@ export interface Prompt {
  * You find an example in the assistant-validations README.
  */
 export interface PromptStateMixinRequirements {
-  /** The current entitiy dictionary, injectable via injectionNames.current.entityDictionary */
+  /** The current entitiy dictionary, injectable via {@link injectionNames.current.entityDictionary} */
   entities: EntityDictionary;
 
-  /** The current session factory, injectable via injectionNames.current.sessionFactory */
+  /** The current session factory, injectable via {@link injectionNames.current.sessionFactory} */
   sessionFactory: CurrentSessionFactory;
 
-  /** Your entity mappings, injectable via "core:unifier:user-entity-mappings" */
+  /** Your entity mappings, injectable via {@link injectionNames.userEntityMappings} */
   mappings: PlatformGenerator.EntityMapping;
 }
 

--- a/src/components/validations/utterance-template-service.ts
+++ b/src/components/validations/utterance-template-service.ts
@@ -1,11 +1,11 @@
-import { PlatformGenerator } from "assistant-source";
+import { injectionNames, PlatformGenerator } from "assistant-source";
 import { inject, injectable } from "inversify";
 
 @injectable()
 export class UtteranceTemplateService implements PlatformGenerator.UtteranceTemplateService {
   private mappings: PlatformGenerator.EntityMapping;
 
-  constructor(@inject("core:unifier:user-entity-mappings") mappings: PlatformGenerator.EntityMapping) {
+  constructor(@inject(injectionNames.userEntityMappings) mappings: PlatformGenerator.EntityMapping) {
     this.mappings = mappings;
   }
 


### PR DESCRIPTION
Adds `validationsInjectionNames':
It contains all global bonded services from the assistant-validations component.