### PR TITLE
Adds suggestions for changing `PromptStateMixin` typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,16 +103,10 @@
         "@types/node": "*"
       }
     },
-    "@types/events": {
-      "version": "1.2.0",
-      "resolved": "http://sinopia.verstehe.local:4873/@types%2fevents/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-      "dev": true
-    },
     "@types/express": {
-      "version": "4.16.0",
-      "resolved": "http://sinopia.verstehe.local:4873/@types%2fexpress/-/express-4.16.0.tgz",
-      "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
+      "version": "4.16.1",
+      "resolved": "http://sinopia.verstehe.local:4873/@types%2fexpress/-/express-4.16.1.tgz",
+      "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -121,12 +115,11 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.0",
-      "resolved": "http://sinopia.verstehe.local:4873/@types%2fexpress-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
-      "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
+      "version": "4.16.1",
+      "resolved": "http://sinopia.verstehe.local:4873/@types%2fexpress-serve-static-core/-/express-serve-static-core-4.16.1.tgz",
+      "integrity": "sha512-QgbIMRU1EVRry5cIu1ORCQP4flSYqLM1lS5LYyGWfKnFT3E58f0gKto7BR13clBFVrVZ0G0rbLZ1hUpSkgQQOA==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
         "@types/node": "*",
         "@types/range-parser": "*"
       }
@@ -150,9 +143,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "http://sinopia.verstehe.local:4873/@types%2fnode/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "version": "10.12.21",
+      "resolved": "http://sinopia.verstehe.local:4873/@types%2fnode/-/node-10.12.21.tgz",
+      "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
       "dev": true
     },
     "@types/range-parser": {
@@ -555,9 +548,9 @@
       "dev": true
     },
     "assistant-apiai": {
-      "version": "0.4.0-webcom.1901040955",
-      "resolved": "http://sinopia.verstehe.local:4873/assistant-apiai/-/assistant-apiai-0.4.0-webcom.1901040955.tgz",
-      "integrity": "sha512-QCP1nkRrcoGjkIy12hy7JuCzFbuxj/cHoD+BtVPVvQSrf6yhC6USnjK6fNuKhhG+y0CIpTonq6aPWH7BXENbxQ==",
+      "version": "0.4.0-webcom.1902011423",
+      "resolved": "http://sinopia.verstehe.local:4873/assistant-apiai/-/assistant-apiai-0.4.0-webcom.1902011423.tgz",
+      "integrity": "sha512-mY9gEa5l383aLXOriaj4xcNQRAvVgZvDBTKb+8zkBDZmeO39beJCc5H6VgUJaE31KQ2FUD3f96x2ry2qQkvA5Q==",
       "dev": true,
       "requires": {
         "archiver": "^1.3.0",
@@ -565,15 +558,15 @@
       }
     },
     "assistant-google": {
-      "version": "0.4.0-webcom.1901040957",
-      "resolved": "http://sinopia.verstehe.local:4873/assistant-google/-/assistant-google-0.4.0-webcom.1901040957.tgz",
-      "integrity": "sha512-1XEpK6DvmtazwdjL0LJ3K8n+1XxBLr6h23cVgsW2DlfuXZ1n4Z11GBxx0d8MiQG/p0Wafl26cVfcakn4a0InkQ==",
+      "version": "0.4.0-webcom.1902011421",
+      "resolved": "http://sinopia.verstehe.local:4873/assistant-google/-/assistant-google-0.4.0-webcom.1902011421.tgz",
+      "integrity": "sha512-SAzRaW8F8RfUcI4XzvSz/6nHO8uSSoii7yOcFCYP8wDzi7fs8O2ear+WvIzgcE4nyv9Gn0/c5WNJ/HloK7aPEA==",
       "dev": true
     },
     "assistant-source": {
-      "version": "0.4.0-webcom.1901040923",
-      "resolved": "http://sinopia.verstehe.local:4873/assistant-source/-/assistant-source-0.4.0-webcom.1901040923.tgz",
-      "integrity": "sha512-XWAoxvtWoh50AVJih6zMCC2zD/n9HPPOTKYDpeaPbM11yrS8Wwh7HCelTVWHyerX8uN1DlQtywbE9ibMwngEGw==",
+      "version": "0.4.0-webcom.1901281250",
+      "resolved": "http://sinopia.verstehe.local:4873/assistant-source/-/assistant-source-0.4.0-webcom.1901281250.tgz",
+      "integrity": "sha512-BJFzcU+FdTnVy1cw90RLXRfOOgDVWfU26X5BAXPgjGljtIeaod+SaB0A2wVEp1D1GZbCfMnv4edwUZ0/6HiNlQ==",
       "dev": true,
       "requires": {
         "@types/bunyan": "^1.8.4",
@@ -590,7 +583,7 @@
         "inversify": "4.1.1",
         "inversify-components": "^0.4.0",
         "js-combinatorics": "^0.5.3",
-        "redis": "^2.8.0",
+        "redis": "2.8.0",
         "reflect-metadata": "^0.1.12",
         "resolve": "^1.8.1",
         "rxjs": "^5.5.11"
@@ -609,9 +602,9 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.9.0",
-          "resolved": "http://sinopia.verstehe.local:4873/resolve/-/resolve-1.9.0.tgz",
-          "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+          "version": "1.10.0",
+          "resolved": "http://sinopia.verstehe.local:4873/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -2316,14 +2309,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2338,20 +2329,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2468,8 +2456,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2481,7 +2468,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2496,7 +2482,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2504,14 +2489,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2530,7 +2513,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2611,8 +2593,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2624,7 +2605,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2746,7 +2726,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3934,22 +3913,28 @@
       "dev": true
     },
     "inversify-components": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/inversify-components/-/inversify-components-0.4.0.tgz",
-      "integrity": "sha512-qqAtsMqZunvjRPVj3Y55E6Dj1V6OLTUCCPSzhpsSElD8JpQDCzSzBJX4MIEndIYMxEdUoA7THOtuTy3IItiZ8g==",
+      "version": "0.4.2",
+      "resolved": "http://sinopia.verstehe.local:4873/inversify-components/-/inversify-components-0.4.2.tgz",
+      "integrity": "sha512-SiGdZ48LfOCcEVHjDummm/rNI4NfVY13QTma3qu9h2VXqM47gv+9X5BJcG7zi+zQnzzR9nH40kSb1eOSQmYR6Q==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "http://sinopia.verstehe.local:4873/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "http://sinopia.verstehe.local:4873/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -4768,9 +4753,9 @@
       }
     },
     "moment": {
-      "version": "2.23.0",
-      "resolved": "http://sinopia.verstehe.local:4873/moment/-/moment-2.23.0.tgz",
-      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==",
+      "version": "2.24.0",
+      "resolved": "http://sinopia.verstehe.local:4873/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
       "dev": true,
       "optional": true
     },
@@ -4829,10 +4814,9 @@
       }
     },
     "natives": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
-      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
-      "dev": true
+      "version": "1.1.6",
+      "resolved": "http://sinopia.verstehe.local:4873/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
     },
     "ncp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,15 @@
   "peerDependencies": {
     "assistant-source": "^0.4.0",
     "inversify": "4.1.1",
-    "inversify-components": "^0.4.0"
+    "inversify-components": "^0.4.2"
   },
   "devDependencies": {
     "@types/jasmine": "^2.8.8",
     "@types/reflect-metadata": "0.0.5",
-    "assistant-google": "internal",
     "assistant-apiai": "internal",
-    "assistant-source": "internal",
+    "assistant-google": "internal",
+    "assistant-source": "^0.4.0-webcom.1901281250",
+    "atob": ">=2.1.0",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.4.0",
     "gulp-shell": "^0.6.5",
@@ -38,19 +39,21 @@
     "gulp-typescript": "^4.0.1",
     "gulp-watch": "^5.0.0",
     "inversify": "4.1.1",
-    "inversify-components": "^0.4.0",
+    "inversify-components": "^0.4.2",
     "jasmine-spec-reporter": "^4.2.1",
     "jasmine-ts": "^0.2.1",
+    "lodash": ">=4.17.5",
     "nyc": "^11.9.0",
     "prettier": "1.10.2",
     "reflect-metadata": "^0.1.12",
     "tslint": "^5.4.0",
     "tslint-config-airbnb": "^5.9.2",
     "tslint-config-prettier": "^1.13.0",
-    "typescript": "~2.9.2",
-    "lodash": ">=4.17.5",
-    "atob": ">=2.1.0"
+    "typescript": "~2.9.2"
   },
   "main": "./lib/assistant-validations.js",
-  "typings": "./dts/assistant-validations.d.ts"
+  "typings": "./dts/assistant-validations.d.ts",
+  "dependencies": {
+    "natives": "^1.1.6"
+  }
 }

--- a/spec/support/mocks/states/prompt.ts
+++ b/spec/support/mocks/states/prompt.ts
@@ -34,7 +34,7 @@ export class PromptState<MergedAnswerTypes extends BasicAnswerTypes, MergedHandl
     @inject(injectionNames.current.stateSetupSet) setupSet: State.SetupSet<MergedAnswerTypes, MergedHandler>,
     @inject(injectionNames.current.entityDictionary) entities: EntityDictionary,
     @inject(injectionNames.current.sessionFactory) sessionFactory: CurrentSessionFactory,
-    @inject(injectionNames.userEntityMappings) mappings: PlatformGenerator.EntityMapping
+    @inject(injectionNames.userEntityMapping) mappings: PlatformGenerator.EntityMapping
   ) {
     super(setupSet, entities, sessionFactory, mappings);
   }

--- a/spec/support/mocks/states/prompt.ts
+++ b/spec/support/mocks/states/prompt.ts
@@ -29,7 +29,7 @@ class PromptStateRequirements<MergedAnswerTypes extends BasicAnswerTypes, Merged
 @injectable()
 export class PromptState<MergedAnswerTypes extends BasicAnswerTypes, MergedHandler extends BasicHandable<MergedAnswerTypes>> extends PromptStateMixin(
   PromptStateRequirements
-)<MergedAnswerTypes, MergedHandler> {
+) {
   constructor(
     @inject(injectionNames.current.stateSetupSet) setupSet: State.SetupSet<MergedAnswerTypes, MergedHandler>,
     @inject(injectionNames.current.entityDictionary) entities: EntityDictionary,

--- a/src/components/validations/prompt-state-mixin.ts
+++ b/src/components/validations/prompt-state-mixin.ts
@@ -13,38 +13,12 @@ import {
 import { COMPONENT_NAME } from "./private-interfaces";
 import { HookContext, PromptStateMixinInstance, PromptStateMixinRequirements } from "./public-interfaces";
 
+// Defines the public members requirements to an instance of a prompt state
+type PromptStateInstanceRequirements = BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements;
 
-/**
- * The mixin's return type has a flaw in the return type. According to some findings, e.g. https://github.com/Microsoft/TypeScript/issues/10261, 
- * the intersection of two Constructor types is not considered to be Constructor type itself. Hence, `Constructor<PromptStateMixinInstance> & T` 
- * is not instantiable (by type, actually it is). The solution is not to intersect two Constructor types, but to intersect the return type of the
- * constructor. There're two possible ways.
- * 
- * The first one uses the `InstanceType` mapped type and does not require an adaption of the generic:
- * 
- * export declare function PromptStateMixin<T extends Constructor<BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements>>(superState: T): Constructor<PromptStateMixinInstance & InstanceType<T>>;
- * 
- * However, this results in an non-static return type as `InstanceType` uses conditionals. Consequently, TypeScript does not allow to extend from
- * this immediately; it must've been explicitely casted to a static type:
- * 
- * 
- * const mixedState = PromptStateMixin(superState) as Constructor<PromptStateMixinInstance & BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements>;
- *
- * @injectable()
- * class LeanPromptState extends mixedState {}
- * 
- * 
- * The alternative is to alter return type and the generic, which works like a charm, but may have some implications in existing projects (though I can't imagine any):
- * 
- * export declare function PromptStateMixin<T extends Constructor<I>, I extends BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements>(superState: T): Constructor<PromptStateMixinInstance & I>;
- * 
- */
-
-
-
-export function PromptStateMixin<T extends Constructor<BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements>>(
+export function PromptStateMixin<T extends Constructor<PromptStateInstanceRequirements>>(
   superState: T
-): Constructor<PromptStateMixinInstance> & T {
+): Constructor<PromptStateMixinInstance & PromptStateInstanceRequirements> {
   return class extends superState {
     public async invokeGenericIntent(machine: Transitionable, tellInvokeMessage = true, ...additionalArgs: any[]) {
       const promises = await Promise.all([this.unserializeHook(), this.storeCurrentEntitiesToSession()]);

--- a/src/components/validations/prompt-state-mixin.ts
+++ b/src/components/validations/prompt-state-mixin.ts
@@ -28,7 +28,7 @@ import { HookContext, PromptStateMixinInstance, PromptStateMixinRequirements } f
  * this immediately; it must've been explicitely casted to a static type:
  * 
  * 
- * const mixedState = PromptStateMixin(superState);
+ * const mixedState = PromptStateMixin(superState) as Constructor<PromptStateMixinInstance & BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements>;
  *
  * @injectable()
  * class LeanPromptState extends mixedState {}

--- a/src/components/validations/utterance-template-service.ts
+++ b/src/components/validations/utterance-template-service.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from "inversify";
 export class UtteranceTemplateService implements PlatformGenerator.UtteranceTemplateService {
   private mappings: PlatformGenerator.EntityMapping;
 
-  constructor(@inject(injectionNames.userEntityMappings) mappings: PlatformGenerator.EntityMapping) {
+  constructor(@inject(injectionNames.userEntityMapping) mappings: PlatformGenerator.EntityMapping) {
     this.mappings = mappings;
   }
 


### PR DESCRIPTION
The mixin's return type has a flaw in the return type. According to some findings, e.g. https://github.com/Microsoft/TypeScript/issues/10261, the intersection of two Constructor types is not considered to be Constructor type itself. Hence, `Constructor<PromptStateMixinInstance> & T` is not instantiable (by type, actually it is). The solution is not to intersect two Constructor types, but to intersect the return type of the
constructor. There're two possible ways.

The first one uses the `InstanceType` mapped type and does not require an adaption of the generic:

```
export declare function PromptStateMixin<T extends Constructor<BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements>>(superState: T): Constructor<PromptStateMixinInstance & InstanceType<T>>;
```

However, this results in an non-static return type as `InstanceType` uses conditionals. Consequently, TypeScript does not allow to extend from this immediately (https://github.com/Microsoft/TypeScript/issues/27890#issuecomment-429558054); it must've been explicitely casted to a static type:

```
const mixedState = PromptStateMixin(superState) as Constructor<PromptStateMixinInstance & BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements>;
@injectable()
class LeanPromptState extends mixedState {}
```

The alternative is to alter return type and the generic, which works like a charm, but may have some implications in existing projects (though I can't imagine any):

```
export declare function PromptStateMixin<T extends Constructor<I>, I extends BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & PromptStateMixinRequirements>(superState: T): Constructor<PromptStateMixinInstance & I>;
```
