### PR TITLE
Remove mixin return types

### DIFF
--- a/src/components/validations/mixins/common-functions.ts
+++ b/src/components/validations/mixins/common-functions.ts
@@ -4,9 +4,7 @@ import { CommonFunctionsInstanceRequirements, CommonFunctionsMixinInstance, Hook
 /**
  * Add common functions that are used in the different validation states through this mixin
  */
-export function CommonFunctionsMixin<T extends CommonFunctionsInstanceRequirements>(
-  superState: Constructor<T>
-): Constructor<CommonFunctionsMixinInstance & CommonFunctionsInstanceRequirements & T> {
+export function CommonFunctionsMixin<T extends CommonFunctionsInstanceRequirements>(superState: Constructor<T>) {
   // prettier-ignore
   return class extends (superState as any) {
 

--- a/src/components/validations/states/confirmation-state-mixin.ts
+++ b/src/components/validations/states/confirmation-state-mixin.ts
@@ -13,9 +13,7 @@ import {
 // Defines the public members requirements to an instance of a confirmation state
 type ConfirmationStateInstanceRequirements = CommonFunctionsInstanceRequirements & ConfirmationStateMixinRequirements;
 
-export function ConfirmationStateMixin<T extends Constructor<ConfirmationStateInstanceRequirements>>(
-  superState: T
-): Constructor<ConfirmationStateMixinInstance & ConfirmationStateMixinRequirements & CommonFunctionsMixinInstance> {
+export function ConfirmationStateMixin<T extends Constructor<ConfirmationStateInstanceRequirements>>(superState: T) {
   return class extends CommonFunctionsMixin(superState) {
     public async invokeGenericIntent(machine: Transitionable, tellInvokeMessage = true, ...additionalArgs: any[]) {
       if (tellInvokeMessage) {

--- a/src/components/validations/states/prompt-state-mixin.ts
+++ b/src/components/validations/states/prompt-state-mixin.ts
@@ -12,9 +12,7 @@ import {
 // Defines the public members requirements to an instance of a prompt state
 type PromptStateInstanceRequirements = CommonFunctionsInstanceRequirements & PromptStateMixinRequirements;
 
-export function PromptStateMixin<T extends Constructor<PromptStateInstanceRequirements>>(
-  superState: T
-): Constructor<PromptStateMixinInstance & PromptStateInstanceRequirements & CommonFunctionsMixinInstance> {
+export function PromptStateMixin<T extends Constructor<PromptStateInstanceRequirements>>(superState: T) {
   return class extends CommonFunctionsMixin(superState) {
     public async invokeGenericIntent(machine: Transitionable, tellInvokeMessage = true, ...additionalArgs: any[]) {
       const promises = await Promise.all([this.unserializeHookContext<ValidationStrategy.Prompt>(), this.storeCurrentEntitiesToSession()]);


### PR DESCRIPTION
After long investigation, I'm sure the safest way to deal with promises to infer the return type.