### PR TITLE
Feature/typesafe mixin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,14 +1974,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1996,20 +1994,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2126,8 +2121,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2139,7 +2133,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2154,7 +2147,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2162,14 +2154,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2188,7 +2178,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2269,8 +2258,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2282,7 +2270,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2404,7 +2391,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/spec/support/mocks/states/confirmation-state.ts
+++ b/spec/support/mocks/states/confirmation-state.ts
@@ -17,7 +17,7 @@ class ConfirmationStateRequirements<MergedAnswerTypes extends BasicAnswerTypes, 
 export class ConfirmationState<
   MergedAnswerTypes extends BasicAnswerTypes,
   MergedHandler extends BasicHandable<MergedAnswerTypes>
-> extends ConfirmationStateMixin(ConfirmationStateRequirements) {
+> extends ConfirmationStateMixin(ConfirmationStateRequirements)<MergedAnswerTypes, MergedHandler> {
   constructor(
     @inject(injectionNames.current.stateSetupSet) setupSet: State.SetupSet<MergedAnswerTypes, MergedHandler>,
     @inject(injectionNames.current.sessionFactory) sessionFactory: CurrentSessionFactory

--- a/spec/support/mocks/states/prompt-state.ts
+++ b/spec/support/mocks/states/prompt-state.ts
@@ -9,7 +9,7 @@ import {
   PlatformGenerator,
   State,
 } from "assistant-source";
-import { inject, injectable } from "inversify";
+import { inject, injectable, unmanaged } from "inversify";
 import { PromptStateMixin, PromptStateMixinRequirements } from "../../../../src/assistant-validations";
 
 class PromptStateRequirements<MergedAnswerTypes extends BasicAnswerTypes, MergedHandler extends BasicHandable<MergedAnswerTypes>> extends BaseState<
@@ -17,10 +17,10 @@ class PromptStateRequirements<MergedAnswerTypes extends BasicAnswerTypes, Merged
   MergedHandler
 > implements PromptStateMixinRequirements {
   constructor(
-    stateSetupSet: State.SetupSet<MergedAnswerTypes, MergedHandler>,
-    public entities: EntityDictionary,
-    public sessionFactory: CurrentSessionFactory,
-    public mappings: PlatformGenerator.EntityMapping
+    @unmanaged() stateSetupSet: State.SetupSet<MergedAnswerTypes, MergedHandler>,
+    @unmanaged() public entities: EntityDictionary,
+    @unmanaged() public sessionFactory: CurrentSessionFactory,
+    @unmanaged() public mappings: PlatformGenerator.EntityMapping
   ) {
     super(stateSetupSet);
   }
@@ -29,7 +29,7 @@ class PromptStateRequirements<MergedAnswerTypes extends BasicAnswerTypes, Merged
 @injectable()
 export class PromptState<MergedAnswerTypes extends BasicAnswerTypes, MergedHandler extends BasicHandable<MergedAnswerTypes>> extends PromptStateMixin(
   PromptStateRequirements
-) {
+)<MergedAnswerTypes, MergedHandler> {
   constructor(
     @inject(injectionNames.current.stateSetupSet) setupSet: State.SetupSet<MergedAnswerTypes, MergedHandler>,
     @inject(injectionNames.current.entityDictionary) entities: EntityDictionary,

--- a/src/components/validations/mixins/common-functions.ts
+++ b/src/components/validations/mixins/common-functions.ts
@@ -1,6 +1,6 @@
 import { BasicAnswerTypes, Constructor, featureIsAvailable, OptionalHandlerFeatures, SuggestionChipsMixin } from "assistant-source";
 import { COMPONENT_NAME } from "../private-interfaces";
-import { CommonFunctionsInstanceRequirements, CommonFunctionsMixinInstance, HookContext, sessionKeys, ValidationStrategy } from "../public-interfaces";
+import { CommonFunctionsMixinInstance, CommonFunctionsMixinRequirements, HookContext, sessionKeys, ValidationStrategy } from "../public-interfaces";
 /**
  * Add common functions that are used in the different validation states through this mixin.
  *
@@ -8,7 +8,7 @@ import { CommonFunctionsInstanceRequirements, CommonFunctionsMixinInstance, Hook
  * in `BaseState` and TypeScript does not allow to mixin with other than public. Moreover, I cannot just extend `BaseState` due to an
  * issue with type definition for `logger`.
  */
-export function CommonFunctionsMixin<T extends Constructor<CommonFunctionsInstanceRequirements>>(superState: T): T & Constructor<CommonFunctionsMixinInstance> {
+export function CommonFunctionsMixin<T extends Constructor<CommonFunctionsMixinRequirements>>(superState: T): T & Constructor<CommonFunctionsMixinInstance> {
   return class extends superState implements CommonFunctionsMixinInstance {
     /**
      * Unserializes hook context

--- a/src/components/validations/mixins/common-functions.ts
+++ b/src/components/validations/mixins/common-functions.ts
@@ -49,9 +49,7 @@ export function CommonFunctionsMixin<T extends Constructor<CommonFunctionsMixinR
     public async setSuggestionChips(lookupString: string = ".suggestionChips") {
       try {
         if (featureIsAvailable(this.responseHandler, OptionalHandlerFeatures.FeatureChecker.SuggestionChips)) {
-          ((this.responseHandler as unknown) as SuggestionChipsMixin<BasicAnswerTypes>).setSuggestionChips(
-            await this.translateHelper.getAllAlternatives(lookupString)
-          );
+          ((this.responseHandler as unknown) as SuggestionChipsMixin<BasicAnswerTypes>).setSuggestionChips(await this.translateHelper.getAllAlternatives(lookupString));
         } else {
           this.logger.debug(`Current response handler doesn't support suggestion chips, so not setting any. Lookupstring = ${lookupString}`);
         }

--- a/src/components/validations/mixins/common-functions.ts
+++ b/src/components/validations/mixins/common-functions.ts
@@ -49,7 +49,7 @@ export function CommonFunctionsMixin<T extends Constructor<CommonFunctionsMixinR
     public async setSuggestionChips(lookupString: string = ".suggestionChips") {
       try {
         if (featureIsAvailable(this.responseHandler, OptionalHandlerFeatures.FeatureChecker.SuggestionChips)) {
-          ((this.responseHandler as unknown) as SuggestionChipsMixin<BasicAnswerTypes>).setSuggestionChips(await this.translateHelper.getAllAlternatives(lookupString));
+          (this.responseHandler as unknown as SuggestionChipsMixin<BasicAnswerTypes>).setSuggestionChips(await this.translateHelper.getAllAlternatives(lookupString));
         } else {
           this.logger.debug(`Current response handler doesn't support suggestion chips, so not setting any. Lookupstring = ${lookupString}`);
         }

--- a/src/components/validations/public-interfaces.ts
+++ b/src/components/validations/public-interfaces.ts
@@ -103,16 +103,14 @@ export const sessionKeys = {
  * In your class using the PromptState mixin, just inject all of these requirements.
  * You find an example in the assistant-validations README.
  */
-export interface PromptStateMixinRequirements extends State.Required {
-  /** The current entitiy dictionary, injectable via {@link injectionNames.current.entityDictionary} */
-  entities: EntityDictionary;
+export type PromptStateMixinRequirements = CommonFunctionsInstanceRequirements &
+  State.Required & {
+    /** The current entitiy dictionary, injectable via {@link injectionNames.current.entityDictionary} */
+    entities: EntityDictionary;
 
-  /** The current session factory, injectable via {@link injectionNames.current.sessionFactory} */
-  sessionFactory: CurrentSessionFactory;
-
-  /** Your entity mappings, injectable via {@link injectionNames.userEntityMappings} */
-  mappings: PlatformGenerator.EntityMapping;
-}
+    /** Your entity mappings, injectable via {@link injectionNames.userEntityMappings} */
+    mappings: PlatformGenerator.EntityMapping;
+  };
 
 /**
  * Interface describing what you get when applying PromptMixin to one of your states
@@ -186,10 +184,7 @@ export interface PromptStateMixinInstance {
  * In your class using the ConfirmationState mixin, just inject all of these requirements.
  * You find an example in the assistant-validations README.
  */
-export interface ConfirmationStateMixinRequirements extends State.Required {
-  /** The current session factory, injectable via {@link injectionNames.current.sessionFactory} */
-  sessionFactory: CurrentSessionFactory;
-}
+export type ConfirmationStateMixinRequirements = CommonFunctionsInstanceRequirements & State.Required & {};
 
 /**
  * Interface describing what you get when applying ConfirmationMixin to one of your states

--- a/src/components/validations/public-interfaces.ts
+++ b/src/components/validations/public-interfaces.ts
@@ -103,8 +103,8 @@ export const sessionKeys = {
  * In your class using the PromptState mixin, just inject all of these requirements.
  * You find an example in the assistant-validations README.
  */
-export type PromptStateMixinRequirements = CommonFunctionsInstanceRequirements &
-  State.Required & {
+export type PromptStateMixinRequirements = CommonFunctionsMixinRequirements &
+  BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & {
     /** The current entitiy dictionary, injectable via {@link injectionNames.current.entityDictionary} */
     entities: EntityDictionary;
 
@@ -115,7 +115,7 @@ export type PromptStateMixinRequirements = CommonFunctionsInstanceRequirements &
 /**
  * Interface describing what you get when applying PromptMixin to one of your states
  */
-export interface PromptStateMixinInstance {
+export interface PromptStateMixinInstance extends CommonFunctionsMixinInstance, PromptStateMixinRequirements {
   /**
    * Called as an state entrance from promptFactory.
    * @param machine Transitionable interface
@@ -184,12 +184,12 @@ export interface PromptStateMixinInstance {
  * In your class using the ConfirmationState mixin, just inject all of these requirements.
  * You find an example in the assistant-validations README.
  */
-export type ConfirmationStateMixinRequirements = CommonFunctionsInstanceRequirements & State.Required & {};
+export type ConfirmationStateMixinRequirements = CommonFunctionsMixinRequirements & BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> & {};
 
 /**
  * Interface describing what you get when applying ConfirmationMixin to one of your states
  */
-export interface ConfirmationStateMixinInstance {
+export interface ConfirmationStateMixinInstance extends CommonFunctionsMixinInstance, ConfirmationStateMixinRequirements {
   /**
    * Entrance point of the confirmationState, called from validations-initializer
    * @param machine Transitionable interface
@@ -220,7 +220,7 @@ export interface ConfirmationStateMixinInstance {
  * Requirements needed to be able to use the CommonFunctionsMixin. Use this mixin inside of another mixin to get availability
  * to several useful functions, e.g. unserializeHook.
  */
-export interface CommonFunctionsInstanceRequirements extends BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> {
+export interface CommonFunctionsMixinRequirements extends BaseState<BasicAnswerTypes, BasicHandable<BasicAnswerTypes>> {
   /** The current session factory, injectable via {@link injectionNames.current.sessionFactory} */
   sessionFactory: CurrentSessionFactory;
 }
@@ -228,7 +228,7 @@ export interface CommonFunctionsInstanceRequirements extends BaseState<BasicAnsw
 /**
  * Interface of the CommonFunctionsMixin describing the available functions from this mixin
  */
-export interface CommonFunctionsMixinInstance {
+export interface CommonFunctionsMixinInstance extends CommonFunctionsMixinRequirements {
   /**
    * Unserializes hook context
    */

--- a/src/components/validations/states/confirmation-state-mixin.ts
+++ b/src/components/validations/states/confirmation-state-mixin.ts
@@ -1,7 +1,6 @@
 import { Constructor, Transitionable } from "assistant-source";
 import { CommonFunctionsMixin } from "../mixins/common-functions";
 import {
-  CommonFunctionsInstanceRequirements,
   CommonFunctionsMixinInstance,
   ConfirmationResult,
   confirmationResultIdentifier,
@@ -13,9 +12,10 @@ import {
 /**
  * Defines the public members requirements to an instance of a confirmation state.
  */
+export type ConfirmationStateMixin = ReturnType<typeof ConfirmationStateMixin>;
 export function ConfirmationStateMixin<T extends Constructor<ConfirmationStateMixinRequirements>>(
   superState: T
-): T & Constructor<CommonFunctionsMixinInstance & ConfirmationStateMixinRequirements & ConfirmationStateMixinInstance> {
+): T & Constructor<ConfirmationStateMixinInstance> {
   return confirmationStateMixin(CommonFunctionsMixin(superState));
 }
 
@@ -24,7 +24,7 @@ export function ConfirmationStateMixin<T extends Constructor<ConfirmationStateMi
  * delegate this to a helper function to bypass some issues with TypeScript's mixin classes pattern. Those should always
  * strictly look as follows without extra mixins.
  */
-function confirmationStateMixin<T extends Constructor<ConfirmationStateMixinRequirements> & ReturnType<typeof CommonFunctionsMixin>>(superState: T) {
+function confirmationStateMixin<T extends Constructor<CommonFunctionsMixinInstance & ConfirmationStateMixinRequirements>>(superState: T) {
   return class extends superState {
     public async invokeGenericIntent(machine: Transitionable, tellInvokeMessage = true, ...additionalArgs: any[]) {
       if (tellInvokeMessage) {

--- a/src/components/validations/states/confirmation-state-mixin.ts
+++ b/src/components/validations/states/confirmation-state-mixin.ts
@@ -10,13 +10,22 @@ import {
   ValidationStrategy,
 } from "../public-interfaces";
 
-// Defines the public members requirements to an instance of a confirmation state
-type ConfirmationStateInstanceRequirements = CommonFunctionsInstanceRequirements & ConfirmationStateMixinRequirements;
-
-export function ConfirmationStateMixin<T extends Constructor<ConfirmationStateInstanceRequirements>>(
+/**
+ * Defines the public members requirements to an instance of a confirmation state.
+ */
+export function ConfirmationStateMixin<T extends Constructor<ConfirmationStateMixinRequirements>>(
   superState: T
-): Constructor<ConfirmationStateMixinInstance & ConfirmationStateMixinRequirements & CommonFunctionsMixinInstance> {
-  return class extends CommonFunctionsMixin(superState) {
+): T & Constructor<CommonFunctionsMixinInstance & ConfirmationStateMixinRequirements & ConfirmationStateMixinInstance> {
+  return confirmationStateMixin(CommonFunctionsMixin(superState));
+}
+
+/**
+ * The actual mixin function for confirmation state. Because this mixin requires another one, `CommonFunctionsMixin`, we have to
+ * delegate this to a helper function to bypass some issues with TypeScript's mixin classes pattern. Those should always
+ * strictly look as follows without extra mixins.
+ */
+function confirmationStateMixin<T extends Constructor<ConfirmationStateMixinRequirements> & ReturnType<typeof CommonFunctionsMixin>>(superState: T) {
+  return class extends superState {
     public async invokeGenericIntent(machine: Transitionable, tellInvokeMessage = true, ...additionalArgs: any[]) {
       if (tellInvokeMessage) {
         this.handleInvokeMessage(

--- a/src/components/validations/states/prompt-state-mixin.ts
+++ b/src/components/validations/states/prompt-state-mixin.ts
@@ -9,13 +9,22 @@ import {
   ValidationStrategy,
 } from "../public-interfaces";
 
-// Defines the public members requirements to an instance of a prompt state
-type PromptStateInstanceRequirements = CommonFunctionsInstanceRequirements & PromptStateMixinRequirements;
-
-export function PromptStateMixin<T extends Constructor<PromptStateInstanceRequirements>>(
+/**
+ * Defines the public members requirements to an instance of a prompt state.
+ */
+export function PromptStateMixin<T extends Constructor<PromptStateMixinRequirements>>(
   superState: T
-): Constructor<PromptStateMixinInstance & PromptStateInstanceRequirements & CommonFunctionsMixinInstance> {
-  return class extends CommonFunctionsMixin(superState) {
+): T & Constructor<CommonFunctionsMixinInstance & PromptStateMixinRequirements & PromptStateMixinInstance> {
+  return promptStateMixin(CommonFunctionsMixin(superState));
+}
+
+/**
+ * The actual mixin function for prompt state. Because this mixin requires another one, `CommonFunctionsMixin`, we have to
+ * delegate this to a helper function to bypass some issues with TypeScript's mixin classes pattern. Those should always
+ * strictly look as follows without extra mixins.
+ */
+function promptStateMixin<T extends Constructor<PromptStateMixinRequirements> & ReturnType<typeof CommonFunctionsMixin>>(superState: T) {
+  return class extends superState {
     public async invokeGenericIntent(machine: Transitionable, tellInvokeMessage = true, ...additionalArgs: any[]) {
       const promises = await Promise.all([this.unserializeHookContext<ValidationStrategy.Prompt>(), this.storeCurrentEntitiesToSession()]);
       const context = promises[0];

--- a/src/components/validations/states/prompt-state-mixin.ts
+++ b/src/components/validations/states/prompt-state-mixin.ts
@@ -1,17 +1,11 @@
 import { Constructor, GenericIntent, Transitionable } from "assistant-source";
 import { CommonFunctionsMixin } from "../mixins/common-functions";
-import {
-  CommonFunctionsInstanceRequirements,
-  CommonFunctionsMixinInstance,
-  PromptStateMixinInstance,
-  PromptStateMixinRequirements,
-  sessionKeys,
-  ValidationStrategy,
-} from "../public-interfaces";
+import { CommonFunctionsMixinInstance, PromptStateMixinInstance, PromptStateMixinRequirements, sessionKeys, ValidationStrategy } from "../public-interfaces";
 
 /**
  * Defines the public members requirements to an instance of a prompt state.
  */
+export type PromptStateMixin = ReturnType<typeof PromptStateMixin>;
 export function PromptStateMixin<T extends Constructor<PromptStateMixinRequirements>>(
   superState: T
 ): T & Constructor<CommonFunctionsMixinInstance & PromptStateMixinRequirements & PromptStateMixinInstance> {
@@ -23,7 +17,9 @@ export function PromptStateMixin<T extends Constructor<PromptStateMixinRequireme
  * delegate this to a helper function to bypass some issues with TypeScript's mixin classes pattern. Those should always
  * strictly look as follows without extra mixins.
  */
-function promptStateMixin<T extends Constructor<PromptStateMixinRequirements> & ReturnType<typeof CommonFunctionsMixin>>(superState: T) {
+function promptStateMixin<T extends Constructor<CommonFunctionsMixinInstance & PromptStateMixinRequirements> & ReturnType<typeof CommonFunctionsMixin>>(
+  superState: T
+) {
   return class extends superState {
     public async invokeGenericIntent(machine: Transitionable, tellInvokeMessage = true, ...additionalArgs: any[]) {
       const promises = await Promise.all([this.unserializeHookContext<ValidationStrategy.Prompt>(), this.storeCurrentEntitiesToSession()]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declaration": true,
     "target": "es6",
     "module": "commonjs",
     "sourceMap": true,


### PR DESCRIPTION
This is required to achieve a better reuseability. The types were applied in practice and also tested with other projects.

The main contribution of this is better return types for the mixin functions, which need less type assertion. 

Next to that, requirements and instance interfaces are cleaned and are better linked.